### PR TITLE
Fix broken links due to linking to submodules

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,11 +55,11 @@ const modules = getModules();
 //
 // (docPath: string) => { url: string | undefined }
 const getDocOriginUrl = (docPath) => {
-  let p = fs.realpathSync(docPath);
+  let rp = fs.realpathSync(docPath);
   let m = undefined;
 
   for (const module of modules) {
-    if (p.includes(module.path)) {
+    if (rp.includes(module.path)) {
       m = module;
       break;
     }
@@ -67,7 +67,7 @@ const getDocOriginUrl = (docPath) => {
 
   if (m != undefined) {
     const u = m['url'];
-    const p = path.relative(m['path'], docPath);
+    const p = path.relative(m['path'], rp);
     const h = m['hash'];
     return `${u}/blob/${h}/${p}`;
   } else {


### PR DESCRIPTION
Fix the incorrect `editURL` generated during the build process for documents that are symbolically linked to sub-module directories.

For example, `docs/modules/haskell-flake/examples.md`.

before:

```html
<a href="https://github.com/juspay/zero-to-flakes/tree/main/docs/modules/haskell-flake/examples.md" target="_blank" rel="noreferrer noopener" class="theme-edit-this-page"><svg fill="currentColor" height="20" width="20" viewBox="0 0 40 40" class="iconEdit_Z9Sw" aria-hidden="true"><g><path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z"></path></g></svg>Edit this page</a>
```

after:

```html
<a href="https://github.com/srid/haskell-flake/blob/c8622c8a259e18e0a1919462ce885380108a723c/doc/examples.md" target="_blank" rel="noreferrer noopener" class="theme-edit-this-page"><svg fill="currentColor" height="20" width="20" viewBox="0 0 40 40" class="iconEdit_Z9Sw" aria-hidden="true"><g><path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z"></path></g></svg>Edit this page</a>
```

reslove #8 