### PR TITLE
Gotchas: don't use `--check-contents`

### DIFF
--- a/docs/gotchas.mdx
+++ b/docs/gotchas.mdx
@@ -64,5 +64,5 @@ error: getting status of '/nix/store/....drv': No such file or directory
 You can try to fix it by running:
 
 ```
-nix-store --verify --check-contents --repair
+nix-store --verify --repair
 ```


### PR DESCRIPTION
From the nix-store manpages:
```
Checks  that  the contents of every valid store path has not been
altered by computing a SHA-256 hash of the contents and
comparing it with the hash stored in the Nix database at build time.
Paths that have been modified are printed out. 
For large stores, --check-contents  is  obviously quite slow.
```
In most cases, when a sqlite database is corrupted and nix errors out with "No such file or directory", the only requirement is to remove the respective path from the DB. Hence, there is no need to go to every single store path and re-compute the SHA-256 and verify if they haven't been altered.